### PR TITLE
feat: 컬럼 기능 구현

### DIFF
--- a/src/main/java/com/kanban/column/controller/BoardColumnController.java
+++ b/src/main/java/com/kanban/column/controller/BoardColumnController.java
@@ -1,0 +1,47 @@
+package com.kanban.column.controller;
+
+import com.kanban.column.dto.*;
+import com.kanban.column.service.BoardColumnService;
+import com.kanban.common.dto.Response;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/board/column")
+@RequiredArgsConstructor
+public class BoardColumnController {
+
+    private final BoardColumnService boardColumnService;
+
+    @GetMapping("/{teamId}")
+    @PreAuthorize("hasAnyAuthority(#teamId + '_LEADER', #teamId + '_MEMBER')")
+    public Response<FindBoardColumnResponse> findAllBoardColumn(@PathVariable Long teamId) {
+        return boardColumnService.findAllBoardColumn(teamId);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority(#addBoardColumnRequest.teamId() + '_LEADER')")
+    public Response<Void> addBoardColumn(@Valid @RequestBody AddBoardColumnRequest addBoardColumnRequest) {
+        return boardColumnService.addBoardColumn(addBoardColumnRequest);
+    }
+
+    @PutMapping("/order")
+    @PreAuthorize("hasAnyAuthority(#request.teamId() + '_LEADER', #request.teamId() + '_MEMBER')")
+    public Response<Void> modifyBoardColumnOrder(@Valid @RequestBody ModifyBoardColumnOrderRequest request) {
+        return boardColumnService.modifyBoardColumnOrder(request);
+    }
+
+    @PutMapping("/name")
+    @PreAuthorize("hasAnyAuthority(#request.teamId() + '_LEADER', #request.teamId() + '_MEMBER')")
+    public Response<Void> modifyBoardColumnName(@Valid @RequestBody ModifyBoardColumnNameRequest request) {
+        return boardColumnService.modifyBoardColumnName(request);
+    }
+
+    @DeleteMapping
+    @PreAuthorize("hasAnyAuthority(#request.teamId() + '_LEADER')")
+    public Response<FindBoardColumnResponse> removeBoardColumn(@Valid @RequestBody RemoveBoardColumnRequest request) {
+        return boardColumnService.removeBoardColumn(request);
+    }
+}

--- a/src/main/java/com/kanban/column/dto/AddBoardColumnRequest.java
+++ b/src/main/java/com/kanban/column/dto/AddBoardColumnRequest.java
@@ -1,0 +1,12 @@
+package com.kanban.column.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record AddBoardColumnRequest(
+        @NotNull
+        Long teamId,
+        @NotEmpty
+        String columnName
+) {
+}

--- a/src/main/java/com/kanban/column/dto/FindBoardColumnResponse.java
+++ b/src/main/java/com/kanban/column/dto/FindBoardColumnResponse.java
@@ -1,0 +1,11 @@
+package com.kanban.column.dto;
+
+import com.kanban.column.entity.BoardColumn;
+
+import java.util.List;
+
+public record FindBoardColumnResponse(
+        Long teamId,
+        List<BoardColumn> boardColumns
+) {
+}

--- a/src/main/java/com/kanban/column/dto/ModifyBoardColumnNameRequest.java
+++ b/src/main/java/com/kanban/column/dto/ModifyBoardColumnNameRequest.java
@@ -1,0 +1,8 @@
+package com.kanban.column.dto;
+
+public record ModifyBoardColumnNameRequest(
+        Long teamId,
+        Long columnId,
+        String columnName
+) {
+}

--- a/src/main/java/com/kanban/column/dto/ModifyBoardColumnOrderRequest.java
+++ b/src/main/java/com/kanban/column/dto/ModifyBoardColumnOrderRequest.java
@@ -1,0 +1,13 @@
+package com.kanban.column.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ModifyBoardColumnOrderRequest(
+        @NotNull
+        Long teamId,
+        @NotNull
+        Long orderAColumnId,
+        @NotNull
+        Long orderBColumnId
+) {
+}

--- a/src/main/java/com/kanban/column/dto/RemoveBoardColumnRequest.java
+++ b/src/main/java/com/kanban/column/dto/RemoveBoardColumnRequest.java
@@ -1,0 +1,7 @@
+package com.kanban.column.dto;
+
+public record RemoveBoardColumnRequest(
+        Long teamId,
+        Long columnId
+) {
+}

--- a/src/main/java/com/kanban/column/entity/BoardColumn.java
+++ b/src/main/java/com/kanban/column/entity/BoardColumn.java
@@ -1,5 +1,6 @@
 package com.kanban.column.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kanban.team.entity.Team;
 import com.kanban.ticket.entity.Ticket;
 import jakarta.persistence.*;
@@ -26,6 +27,7 @@ public class BoardColumn {
     private String name;
 
     @ManyToOne
+    @JsonIgnore
     @JoinColumn(name = "team_id")
     private Team team;
 

--- a/src/main/java/com/kanban/column/entity/BoardColumn.java
+++ b/src/main/java/com/kanban/column/entity/BoardColumn.java
@@ -13,7 +13,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BoardColumn {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "board_column_id", nullable = false)
     private Long id;
 

--- a/src/main/java/com/kanban/column/entity/BoardColumn.java
+++ b/src/main/java/com/kanban/column/entity/BoardColumn.java
@@ -26,7 +26,7 @@ public class BoardColumn {
     @Column(nullable = false)
     private String name;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     @JoinColumn(name = "team_id")
     private Team team;

--- a/src/main/java/com/kanban/column/repository/BoardColumnRepository.java
+++ b/src/main/java/com/kanban/column/repository/BoardColumnRepository.java
@@ -1,0 +1,19 @@
+package com.kanban.column.repository;
+
+import com.kanban.column.entity.BoardColumn;
+import com.kanban.team.entity.Team;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BoardColumnRepository extends JpaRepository<BoardColumn, Long> {
+
+    int countByTeam(Team team);
+
+    @EntityGraph(attributePaths = {"tickets"})
+    List<BoardColumn> findByTeamOrderByOrderNumber(Team team);
+
+    Optional<BoardColumn> findBoardColumnByTeamIdAndId(Long teamId, Long id);
+}

--- a/src/main/java/com/kanban/column/service/BoardColumnService.java
+++ b/src/main/java/com/kanban/column/service/BoardColumnService.java
@@ -1,0 +1,102 @@
+package com.kanban.column.service;
+
+import com.kanban.column.dto.*;
+import com.kanban.column.entity.BoardColumn;
+import com.kanban.column.repository.BoardColumnRepository;
+import com.kanban.common.dto.Response;
+import com.kanban.common.exception.CustomException;
+import com.kanban.common.exception.ErrorCode;
+import com.kanban.team.entity.Team;
+import com.kanban.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class BoardColumnService {
+
+    private final BoardColumnRepository boardColumnRepository;
+    private final TeamRepository teamRepository;
+
+    public Response<FindBoardColumnResponse> findAllBoardColumn(Long teamId) {
+        Team team = findTeamByIdOrElseThrow(teamId);
+        List<BoardColumn> boardColumns = boardColumnRepository.findByTeamOrderByOrderNumber(team);
+
+        FindBoardColumnResponse findBoardColumnResponse = new FindBoardColumnResponse(team.getId(), boardColumns);
+        return Response.success(findBoardColumnResponse);
+    }
+
+    @Transactional
+    public Response<Void> addBoardColumn(AddBoardColumnRequest request) {
+        Team team = findTeamByIdOrElseThrow(request.teamId());
+
+        int order = boardColumnRepository.countByTeam(team) + 1;
+        BoardColumn boardColumn = BoardColumn.builder()
+                .team(team)
+                .orderNumber(order)
+                .name(request.columnName())
+                .build();
+
+        boardColumnRepository.save(boardColumn);
+
+        return Response.successVoid();
+    }
+
+    @Transactional
+    public Response<Void> modifyBoardColumnOrder(ModifyBoardColumnOrderRequest request) {
+        BoardColumn boardColumnA = findBoardColumnByTeamIdAndIdOrElseThrow(request.teamId(), request.orderAColumnId());
+        BoardColumn boardColumnB = findBoardColumnByTeamIdAndIdOrElseThrow(request.teamId(), request.orderBColumnId());
+
+        int temp = boardColumnB.getOrderNumber();
+        boardColumnB.setOrderNumber(boardColumnA.getOrderNumber());
+        boardColumnA.setOrderNumber(temp);
+
+        boardColumnRepository.saveAll(List.of(boardColumnA, boardColumnB));
+
+        return Response.successVoid();
+    }
+
+    @Transactional
+    public Response<Void> modifyBoardColumnName(ModifyBoardColumnNameRequest request) {
+        BoardColumn boardColumn = findBoardColumnByTeamIdAndIdOrElseThrow(request.teamId(), request.columnId());
+
+        boardColumn.setName(request.columnName());
+        boardColumnRepository.save(boardColumn);
+
+        return Response.successVoid();
+    }
+
+    @Transactional
+    public Response<FindBoardColumnResponse> removeBoardColumn(RemoveBoardColumnRequest request) {
+        BoardColumn boardColumn = findBoardColumnByTeamIdAndIdOrElseThrow(request.teamId(), request.columnId());
+        boardColumnRepository.delete(boardColumn);
+
+        Team team = findTeamByIdOrElseThrow(request.teamId());
+        List<BoardColumn> boardColumns = boardColumnRepository.findByTeamOrderByOrderNumber(team);
+
+        IntStream.range(0, boardColumns.size())
+                .forEach(index -> boardColumns.get(index).setOrderNumber(index + 1));
+        boardColumnRepository.saveAll(boardColumns);
+
+        FindBoardColumnResponse findBoardColumnResponse = new FindBoardColumnResponse(team.getId(), boardColumns);
+        return Response.success(findBoardColumnResponse);
+    }
+
+    private Team findTeamByIdOrElseThrow(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(
+                        () -> new CustomException(ErrorCode.TEAM_NOT_FOUND)
+                );
+    }
+
+    private BoardColumn findBoardColumnByTeamIdAndIdOrElseThrow(Long teamId, Long columnId) {
+        return boardColumnRepository.findBoardColumnByTeamIdAndId(teamId, columnId)
+                .orElseThrow(
+                        () -> new CustomException(ErrorCode.BOARD_COLUMN_NOT_FOUND)
+                );
+    }
+}

--- a/src/main/java/com/kanban/common/exception/ErrorCode.java
+++ b/src/main/java/com/kanban/common/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
     INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "I001", "존재하지 않는 초대 입니다."),
     INVITE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "I002", "이미 초대를 하였거나 팀의 멤버입니다."),
 
+    //BoardColumn
+    BOARD_COLUMN_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "존재하지 않는 컬럼 입니다."),
+
     //auth
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "잘못된 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다.")

--- a/src/main/java/com/kanban/team/entity/Invite.java
+++ b/src/main/java/com/kanban/team/entity/Invite.java
@@ -12,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Invite {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "invite_id", nullable = false)
     private Long id;
 

--- a/src/main/java/com/kanban/team/entity/Team.java
+++ b/src/main/java/com/kanban/team/entity/Team.java
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Team {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "team_id", nullable = false)
     private Long id;
 

--- a/src/main/java/com/kanban/ticket/entity/Ticket.java
+++ b/src/main/java/com/kanban/ticket/entity/Ticket.java
@@ -1,5 +1,6 @@
 package com.kanban.ticket.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kanban.column.entity.BoardColumn;
 import com.kanban.ticket.enums.Tag;
 import com.kanban.user.entity.User;
@@ -35,10 +36,12 @@ public class Ticket {
     private LocalDate deadline;
 
     @ManyToOne
+    @JsonIgnore
     @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne
+    @JsonIgnore
     @JoinColumn(name = "board_column_id")
     private BoardColumn boardColumn;
 

--- a/src/main/java/com/kanban/ticket/entity/Ticket.java
+++ b/src/main/java/com/kanban/ticket/entity/Ticket.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Ticket {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ticket_id", nullable = false)
     private Long id;
 

--- a/src/main/java/com/kanban/ticket/entity/Ticket.java
+++ b/src/main/java/com/kanban/ticket/entity/Ticket.java
@@ -35,12 +35,12 @@ public class Ticket {
     @Column(nullable = false)
     private LocalDate deadline;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     @JoinColumn(name = "board_column_id")
     private BoardColumn boardColumn;

--- a/src/main/java/com/kanban/user/entity/User.java
+++ b/src/main/java/com/kanban/user/entity/User.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User implements UserDetails {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id", nullable = false)
     private Long id;
 

--- a/src/test/java/com/kanban/column/service/BoardColumnServiceTest.java
+++ b/src/test/java/com/kanban/column/service/BoardColumnServiceTest.java
@@ -1,0 +1,181 @@
+package com.kanban.column.service;
+
+import com.kanban.column.dto.*;
+import com.kanban.column.entity.BoardColumn;
+import com.kanban.column.repository.BoardColumnRepository;
+import com.kanban.common.dto.Response;
+import com.kanban.team.entity.Team;
+import com.kanban.team.repository.TeamRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BoardColumnServiceTest {
+
+    @Mock
+    private BoardColumnRepository boardColumnRepository;
+    @Mock
+    private TeamRepository teamRepository;
+    @InjectMocks
+    private BoardColumnService boardColumnService;
+
+    @Test
+    @DisplayName("findAllBoardColumn - 성공")
+    void should_successFindAllBoardColumn_when_validRequest() {
+        // given
+        Long teamId = 1L;
+        Team team = mock(Team.class);
+        ReflectionTestUtils.setField(team,"id",1L);
+
+        BoardColumn boardColumn1 = mock(BoardColumn.class);
+        BoardColumn boardColumn2 = mock(BoardColumn.class);
+        BoardColumn boardColumn3 = mock(BoardColumn.class);
+        List<BoardColumn> boardColumns = List.of(boardColumn1, boardColumn2, boardColumn3);
+
+        FindBoardColumnResponse findBoardColumnResponse = new FindBoardColumnResponse(team.getId(), boardColumns);
+
+        when(teamRepository.findById(teamId))
+                .thenReturn(Optional.of(team));
+        when(boardColumnRepository.findByTeamOrderByOrderNumber(team))
+                .thenReturn(boardColumns);
+
+        // when
+        Response<FindBoardColumnResponse> result = boardColumnService.findAllBoardColumn(teamId);
+
+        // then
+        assertThat(boardColumns).isEqualTo(result.data().boardColumns());
+    }
+    
+    @Test
+    @DisplayName("addBoardColumn - 성공")
+    void should_successAddBoardColumn_when_validRequest() {
+        // given
+        AddBoardColumnRequest request = new AddBoardColumnRequest(1L, "testColumn");
+
+        Team team = mock(Team.class);
+        int teamSize = 10;
+
+        BoardColumn boardColumn = mock(BoardColumn.class);
+
+        when(teamRepository.findById(request.teamId()))
+                .thenReturn(Optional.of(team));
+        when(boardColumnRepository.countByTeam(team))
+                .thenReturn(teamSize);
+        when(boardColumnRepository.save(any(BoardColumn.class)))
+                .thenReturn(boardColumn);
+
+        Response<Void> actualResponse = Response.successVoid();
+
+        // when
+        Response<Void> expectResponse = boardColumnService.addBoardColumn(request);
+
+        // then
+        assertThat(actualResponse).isEqualTo(expectResponse);
+    }
+    
+    @Test
+    @DisplayName("removeBoardColumn - 성공")
+    void should_successRemoveBoardColumn_when_validRequest() {
+        // given
+        Long teamId = 1L;
+        Long columnId = 2L;
+        RemoveBoardColumnRequest request = new RemoveBoardColumnRequest(teamId, columnId);
+
+        BoardColumn boardColumn = mock(BoardColumn.class);
+        Team team = mock(Team.class);
+        ReflectionTestUtils.setField(team, "id", teamId);
+
+        BoardColumn reorderColumn1 = mock(BoardColumn.class);
+        BoardColumn reorderColumn2 = mock(BoardColumn.class);
+        BoardColumn reorderColumn3 = mock(BoardColumn.class);
+        List<BoardColumn> reorderColumnList = List.of(reorderColumn1, reorderColumn2, reorderColumn3);
+
+        when(boardColumnRepository.findBoardColumnByTeamIdAndId(request.teamId(), request.columnId()))
+                .thenReturn(Optional.of(boardColumn));
+        doNothing().when(boardColumnRepository).delete(boardColumn);
+        when(teamRepository.findById(request.teamId()))
+                .thenReturn(Optional.of(team));
+        when(boardColumnRepository.findByTeamOrderByOrderNumber(team))
+                .thenReturn(reorderColumnList);
+        when(boardColumnRepository.saveAll(reorderColumnList))
+                .thenReturn(reorderColumnList);
+
+        FindBoardColumnResponse actualResponse = new FindBoardColumnResponse(team.getId(), reorderColumnList);
+
+        // when
+        Response<FindBoardColumnResponse> expectResponse = boardColumnService.removeBoardColumn(request);
+
+        // then
+        assertThat(actualResponse).isEqualTo(expectResponse.data());
+    }
+
+    @Test
+    @DisplayName("modifyBoardColumnOrder - 성공")
+    void should_successModifyBoardColumnOrder_when_validRequest() {
+        // given
+        Long teamId = 1L;
+        Long columnAId = 1L;
+        Long columnBId = 2L;
+        ModifyBoardColumnOrderRequest request = new ModifyBoardColumnOrderRequest(teamId, columnAId, columnBId);
+
+        int orderA = 1;
+        int orderB = 2;
+        BoardColumn columnA = mock(BoardColumn.class);
+        BoardColumn columnB = mock(BoardColumn.class);
+        columnA.setOrderNumber(orderA);
+        columnB.setOrderNumber(orderB);
+        List<BoardColumn> modifiedColumns = List.of(columnA, columnB);
+
+        when(boardColumnRepository.findBoardColumnByTeamIdAndId(request.teamId(), request.orderAColumnId()))
+                .thenReturn(Optional.of(columnA));
+        when(boardColumnRepository.findBoardColumnByTeamIdAndId(request.teamId(), request.orderBColumnId()))
+                .thenReturn(Optional.of(columnB));
+        when(boardColumnRepository.saveAll(modifiedColumns))
+                .thenReturn(modifiedColumns);
+
+        Response<Void> actualResponse = Response.successVoid();
+
+        // when
+        Response<Void> expectResponse = boardColumnService.modifyBoardColumnOrder(request);
+
+        // then
+        assertThat(actualResponse).isEqualTo(expectResponse);
+    }
+    
+    @Test
+    @DisplayName("modifyBoardColumnName - 성공")
+    void should_successModifyBoardColumnName_when_validRequest() {
+        // given
+        Long teamId = 1L;
+        Long columnId = 1L;
+        String columnName = "modifiedName";
+        ModifyBoardColumnNameRequest request = new ModifyBoardColumnNameRequest(teamId, columnId, columnName);
+
+        BoardColumn boardColumn = mock(BoardColumn.class);
+
+        when(boardColumnRepository.findBoardColumnByTeamIdAndId(request.teamId(), request.columnId()))
+                .thenReturn(Optional.of(boardColumn));
+        when(boardColumnRepository.save(boardColumn))
+                .thenReturn(boardColumn);
+
+        Response<Void> actualResponse = Response.successVoid();
+
+        // when
+        Response<Void> expectResponse = boardColumnService.modifyBoardColumnName(request);
+
+        // then
+        assertThat(actualResponse).isEqualTo(expectResponse);
+    }
+}


### PR DESCRIPTION
## Type of change
- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] documentation update

## Describe your changes
### SEQUENCE 를 IDENTITY 로 변경
MySQL 은 SEQUENCE 를 지원하지 않아 시퀀스 테이블이 하나 더 생성이 되며, 시퀀스 테이블에서 시퀀스 값을 가져와야 하기에 부적절하다.

### Json 직렬화 시 무한 참조 발생
엔티티 관계가 원형으로 되어있기 때문에 BoardColumn 을 Json 으로 직렬화 시 무한 참조가 발생하여 ```@JsonIgnore``` 로 해결
### 컬럼을 위한 기능 구현
- 조회
- 추가
- 순서 변경
- 이름 변경
- 삭제

## Issue ticket number and link
#12 

## Checklist before requesting a review
- [x] 리뷰
- [x] 테스트 코드
