### PR TITLE
refactor: jwt authority

### DIFF
--- a/src/main/java/com/kanban/auth/jwt/JwtUtils.java
+++ b/src/main/java/com/kanban/auth/jwt/JwtUtils.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 public interface JwtUtils {
     String extractUserName(String token);
     Collection<? extends GrantedAuthority> extractAuthorities(String token);
-    String generateAccessToken(Authentication authentication);
+    String generateAccessToken(Authentication authentication, String authoritiesToString);
     String generateRefreshToken(Authentication authentication);
     boolean isTokenValid(String token);
 }

--- a/src/main/java/com/kanban/auth/service/AuthCacheService.java
+++ b/src/main/java/com/kanban/auth/service/AuthCacheService.java
@@ -3,20 +3,32 @@ package com.kanban.auth.service;
 import com.kanban.auth.jwt.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.*;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @CacheConfig(
         cacheManager = "refreshCacheManager",
         cacheNames = "refreshKey"
 )
 public class AuthCacheService {
 
+    private final AuthCacheService self;
     private final JwtUtils jwtUtils;
+
+    @Autowired
+    public AuthCacheService(@Lazy AuthCacheService self, JwtUtils jwtUtils) {
+        this.self = self;
+        this.jwtUtils = jwtUtils;
+    }
 
     @CachePut(key = "#authentication.getName()")
     public String addRefreshKey(Authentication authentication) {
@@ -30,5 +42,32 @@ public class AuthCacheService {
     public String findRefreshKey(Authentication authentication) {
         log.info("find user : {} Refresh Key.", authentication.getName());
         return "";
+    }
+
+    @CachePut(key = "#authentication.getName() + ':authority'")
+    public String addAuthorities(Authentication authentication) {
+        log.info("user : {} Authorities added", authentication.getName());
+        return authoritiesToString(authentication.getAuthorities());
+    }
+
+    @Cacheable(
+            key = "#principal + ':authority'",
+            unless = "#result.isEmpty()")
+    public String findAuthorities(String principal) {
+        log.info("find user : {} Authorities", principal);
+        return "";
+    }
+
+    @CachePut(key = "#principal + ':authority'")
+    public String updateAuthorities(String principal, String newAuthority) {
+        log.info("update user : {} Authorities updated");
+        String authorities = self.findAuthorities(principal);
+        return authorities + "," + newAuthority;
+    }
+
+    private String authoritiesToString(Collection<? extends GrantedAuthority> authorities) {
+        return authorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
     }
 }

--- a/src/main/java/com/kanban/team/controller/InviteController.java
+++ b/src/main/java/com/kanban/team/controller/InviteController.java
@@ -31,8 +31,8 @@ public class InviteController {
     }
 
     @PutMapping("/{inviteId}")
-    public Response<Void> updateInvite(@AuthenticationPrincipal String principal,
-                                       @PathVariable Long inviteId) {
-        return inviteService.updateInvite(principal, inviteId);
+    public Response<Void> modifyInviteAccept(@AuthenticationPrincipal String principal,
+                                             @PathVariable Long inviteId) {
+        return inviteService.modifyInviteAccept(principal, inviteId);
     }
 }

--- a/src/main/java/com/kanban/team/service/InviteService.java
+++ b/src/main/java/com/kanban/team/service/InviteService.java
@@ -1,5 +1,6 @@
 package com.kanban.team.service;
 
+import com.kanban.auth.service.AuthCacheService;
 import com.kanban.common.dto.Response;
 import com.kanban.common.exception.CustomException;
 import com.kanban.common.exception.ErrorCode;
@@ -14,6 +15,7 @@ import com.kanban.user.entity.User;
 import com.kanban.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +29,7 @@ public class InviteService {
     private final InviteRepository inviteRepository;
     private final TeamRepository teamRepository;
     private final UserRepository userRepository;
+    private final AuthCacheService authCacheService;
 
     public Response<List<FindInviteResponse>> findAllInvite(String principal) {
         User user = findUserByAccountOrElseThrow(principal);
@@ -63,12 +66,13 @@ public class InviteService {
     }
 
     @Transactional
-    public Response<Void> updateInvite(String principal, Long inviteId) {
+    public Response<Void> modifyInviteAccept(String principal, Long inviteId) {
         User user = findUserByAccountOrElseThrow(principal);
         Invite invite = findAllByUserAndAcceptIsFalseAndIdOrElseThrow(user, inviteId);
 
         invite.setAccept(true);
         inviteRepository.save(invite);
+        authCacheService.updateAuthorities(principal, invite.getTeam().getId() + "_" + "MEMBER");
 
         return Response.successVoid();
     }

--- a/src/main/java/com/kanban/team/service/TeamService.java
+++ b/src/main/java/com/kanban/team/service/TeamService.java
@@ -1,5 +1,6 @@
 package com.kanban.team.service;
 
+import com.kanban.auth.service.AuthCacheService;
 import com.kanban.common.dto.Response;
 import com.kanban.common.exception.CustomException;
 import com.kanban.common.exception.ErrorCode;
@@ -27,6 +28,7 @@ public class TeamService {
     private final UserRepository userRepository;
     private final InviteRepository inviteRepository;
     private final TeamRepository teamRepository;
+    private final AuthCacheService authCacheService;
 
     public Response<List<FindTeamResponse>> findAllTeam(String principal) {
         User user = findUserByAccountOrElseThrow(principal);
@@ -53,8 +55,9 @@ public class TeamService {
                 .accept(true)
                 .build();
 
-        teamRepository.save(team);
+        Team savedTeam = teamRepository.save(team);
         inviteRepository.save(invite);
+        authCacheService.updateAuthorities(principal, savedTeam.getId() + "_" + "LEADER");
 
         return Response.successVoid();
     }

--- a/src/main/java/com/kanban/ticket/service/TicketService.java
+++ b/src/main/java/com/kanban/ticket/service/TicketService.java
@@ -81,8 +81,11 @@ public class TicketService {
         BoardColumn boardColumn = findBoardColumnByTeamIdAndIdOrElseThrow(request.teamId(), request.columnId());
         Ticket ticket = findTicketByBoardColumnIdAndIdOrElseThrow(boardColumn.getId(), request.ticketId());
         ticketRepository.delete(ticket);
+        ticketRepository.flush();
 
-        List<Ticket> tickets = boardColumn.getTickets();
+        List<Ticket> tickets = boardColumn.getTickets().stream()
+                .filter(t -> !t.getId().equals(ticket.getId()))
+                .toList();
         IntStream.range(0, tickets.size())
                 .forEach(index -> tickets.get(index).setOrderNumber(index + 1));
         ticketRepository.saveAll(tickets);

--- a/src/test/java/com/kanban/team/service/InviteServiceTest.java
+++ b/src/test/java/com/kanban/team/service/InviteServiceTest.java
@@ -1,5 +1,6 @@
 package com.kanban.team.service;
 
+import com.kanban.auth.service.AuthCacheService;
 import com.kanban.common.dto.Response;
 import com.kanban.common.exception.CustomException;
 import com.kanban.common.exception.ErrorCode;
@@ -41,6 +42,8 @@ class InviteServiceTest {
     private TeamRepository teamRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private AuthCacheService authCacheService;
 
     @Test
     @DisplayName("findAllInvite - 성공")
@@ -135,8 +138,8 @@ class InviteServiceTest {
     }
     
     @Test
-    @DisplayName("updateInvite - 성공")
-    void should_successUpdateInvite_when_validRequest() {
+    @DisplayName("modifyInviteAccept - 성공")
+    void should_successModifyInviteAccept_when_validRequest() {
         // given
         String principal = "test";
 
@@ -163,9 +166,11 @@ class InviteServiceTest {
                 .thenReturn(Optional.of(invite));
         when(inviteRepository.save(invite))
                 .thenReturn(invite);
+        when(authCacheService.updateAuthorities(principal, invite.getTeam().getId() + "_" + "MEMBER"))
+                .thenReturn(anyString());
 
         // when
-        Response<Void> response = inviteService.updateInvite(principal, inviteId);
+        Response<Void> response = inviteService.modifyInviteAccept(principal, inviteId);
 
         // then
         assertThat(HttpStatus.OK.value()).isEqualTo(response.status());

--- a/src/test/java/com/kanban/team/service/TeamServiceTest.java
+++ b/src/test/java/com/kanban/team/service/TeamServiceTest.java
@@ -1,5 +1,6 @@
 package com.kanban.team.service;
 
+import com.kanban.auth.service.AuthCacheService;
 import com.kanban.common.dto.Response;
 import com.kanban.team.dto.AddTeamRequest;
 import com.kanban.team.dto.FindTeamResponse;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +39,8 @@ class TeamServiceTest {
     private TeamRepository teamRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private AuthCacheService authCacheService;
 
     @Test
     @DisplayName("findAllTeam - 성공")
@@ -105,6 +109,8 @@ class TeamServiceTest {
                 .thenReturn(team);
         when(inviteRepository.save(any(Invite.class)))
                 .thenReturn(invite);
+        when(authCacheService.updateAuthorities(principal, invite.getTeam().getId() + "_" + "LEADER"))
+                .thenReturn(anyString());
 
         // when
         Response<Void> response = teamService.addTeam(principal, request);

--- a/src/test/java/com/kanban/ticket/service/TicketServiceTest.java
+++ b/src/test/java/com/kanban/ticket/service/TicketServiceTest.java
@@ -210,18 +210,25 @@ class TicketServiceTest {
 
         Ticket ticket = spy(Ticket.class);
         ticket.setOrderNumber(3);
+        ticket.setId(3L);
 
         Ticket ticket1 = spy(Ticket.class);
         ticket1.setOrderNumber(1);
+        ticket1.setId(1L);
         Ticket ticket2 = spy(Ticket.class);
-        ticket1.setOrderNumber(2);
+        ticket2.setOrderNumber(2);
+        ticket2.setId(2L);
         Ticket ticket3 = spy(Ticket.class);
-        ticket1.setOrderNumber(4);
+        ticket3.setOrderNumber(4);
+        ticket3.setId(4L);
         Ticket ticket4 = spy(Ticket.class);
-        ticket1.setOrderNumber(5);
+        ticket4.setOrderNumber(5);
+        ticket4.setId(5L);
         Ticket ticket5 = spy(Ticket.class);
-        ticket1.setOrderNumber(6);
-        List<Ticket> tickets = List.of(ticket1, ticket2, ticket3, ticket4, ticket5);
+        ticket5.setOrderNumber(6);
+        ticket5.setId(6L);
+        List<Ticket> tickets = List.of(ticket1, ticket2, ticket, ticket3, ticket4, ticket5);
+        List<Ticket> saveAllTickets = List.of(ticket1, ticket2, ticket3, ticket4, ticket5);
 
         Ticket ticket6 = spy(Ticket.class);
         ticket1.setOrderNumber(1);
@@ -240,9 +247,10 @@ class TicketServiceTest {
         when(ticketRepository.findTicketByBoardColumnIdAndId(column.getId(), request.ticketId()))
                 .thenReturn(Optional.of(ticket));
         doNothing().when(ticketRepository).delete(ticket);
+        doNothing().when(ticketRepository).flush();
         when(column.getTickets())
                 .thenReturn(tickets);
-        when(ticketRepository.saveAll(tickets))
+        when(ticketRepository.saveAll(saveAllTickets))
                 .thenReturn(returnTickets);
 
         // when


### PR DESCRIPTION
## Type of change
- [x] Bug fix 
- [x] New feature 
- [ ] Breaking change
- [ ] documentation update

## Describe your changes
권한이 추가 될 때마다 로그인하여 JWT를 발급받아야하는 문제를 해결하였습니다.

이제 다음과 같이 동작
1. 로그인 시 권한 캐싱
2. 권한 추가 (초대 수락, 팀 추가)
3. 추가된 권한 캐시에 동기화
4. Access 키를 요청하여 키의 Authorities 에 권한 갱신
5. 갱신된 권한의 JWT를 사용하여 서비스 이용

## Issue ticket number and link
Closes #16 

## Checklist before requesting a review
- [x] 리뷰
- [x] 테스트 코드
